### PR TITLE
Fix a require for binary-search

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var search = require('binary-search');
+var search = require('gm-binary-search');
 
 var getLinearPoint = function( t, i ){
 


### PR DESCRIPTION
There is 'gm-binary-search' module in package.json dependencies, but it was referred as 'binary-search' in index.js.
